### PR TITLE
Compile with -std=c++17 flag if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+project(gazebo-realsense)
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
 # Find Gazebo and Includes
@@ -20,6 +21,8 @@ elseif(GAZEBO_MODEL_PATH)
 else()
     GET_FILENAME_COMPONENT(GZRS_MODEL_PATH ${GAZEBO_MEDIA_PATH}/../models ABSOLUTE)
 endif()
+
+set(CMAKE_CXX_FLAGS "-std=c++17 ${CMAKE_CXX_FLAGS}")
 
 # Compiler flags
 set(CUSTOM_COMPILE_FLAGS "-g -Wall")


### PR DESCRIPTION
The latest version of Gazebo requires C++17 so add the flag.

Also add missing `project()` call at beginning of top-level `CMakeLists.txt` file.